### PR TITLE
Correcciones de porcentajes de trackingLog

### DIFF
--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimCompletedListService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimCompletedListService.java
@@ -29,7 +29,6 @@ public class AssistanceAgentClaimCompletedListService extends AbstractGuiService
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class);
 
 		super.getResponse().setAuthorised(status);
-
 	}
 
 	@Override
@@ -50,6 +49,5 @@ public class AssistanceAgentClaimCompletedListService extends AbstractGuiService
 		dataset = super.unbindObject(claim, "registrationMoment", "passengerEmail", "claimType");
 		dataset.put("getIndicator", claim.getIndicator());
 		super.getResponse().addData(dataset);
-
 	}
 }

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimCreateService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimCreateService.java
@@ -58,7 +58,6 @@ public class AssistanceAgentClaimCreateService extends AbstractGuiService<Assist
 
 		super.bindObject(claim, "registrationMoment", "passengerEmail", "description", "claimType", "getIndicator");
 		claim.setLeg(leg);
-
 	}
 
 	@Override

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimDeleteService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimDeleteService.java
@@ -28,6 +28,8 @@ public class AssistanceAgentClaimDeleteService extends AbstractGuiService<Assist
 	@Autowired
 	private AssistanceAgentTrackingLogRepository	trackingLogRepository;
 
+	// AbstractService interface ----------------------------------------------
+
 
 	@Override
 	public void authorise() {

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimPendingListService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimPendingListService.java
@@ -29,7 +29,6 @@ public class AssistanceAgentClaimPendingListService extends AbstractGuiService<A
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class);
 
 		super.getResponse().setAuthorised(status);
-
 	}
 
 	@Override
@@ -50,6 +49,5 @@ public class AssistanceAgentClaimPendingListService extends AbstractGuiService<A
 		dataset = super.unbindObject(claim, "registrationMoment", "passengerEmail", "claimType");
 		dataset.put("getIndicator", claim.getIndicator());
 		super.getResponse().addData(dataset);
-
 	}
 }

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimPublishService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimPublishService.java
@@ -23,6 +23,8 @@ public class AssistanceAgentClaimPublishService extends AbstractGuiService<Assis
 	@Autowired
 	private AssistanceAgentClaimRepository repository;
 
+	// AbstractGuiService interface -------------------------------------------
+
 
 	@Override
 	public void authorise() {
@@ -30,6 +32,7 @@ public class AssistanceAgentClaimPublishService extends AbstractGuiService<Assis
 		int claimId = super.getRequest().getData("id", int.class);
 		Claim claim = this.repository.findClaimById(claimId);
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && claim != null && super.getRequest().getPrincipal().getActiveRealm().getId() == claim.getAssistanceAgent().getId();
+
 		super.getResponse().setAuthorised(status);
 	}
 

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimShowService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimShowService.java
@@ -31,6 +31,7 @@ public class AssistanceAgentClaimShowService extends AbstractGuiService<Assistan
 		int claimId = super.getRequest().getData("id", int.class);
 		Claim claim = this.repository.findClaimById(claimId);
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && claim != null && super.getRequest().getPrincipal().getActiveRealm().getId() == claim.getAssistanceAgent().getId();
+
 		super.getResponse().setAuthorised(status);
 	}
 

--- a/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimUpdateService.java
+++ b/src/main/java/acme/features/assistanceAgent/claim/AssistanceAgentClaimUpdateService.java
@@ -31,6 +31,7 @@ public class AssistanceAgentClaimUpdateService extends AbstractGuiService<Assist
 		int claimId = super.getRequest().getData("id", int.class);
 		Claim claim = this.repository.findClaimById(claimId);
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && claim != null && super.getRequest().getPrincipal().getActiveRealm().getId() == claim.getAssistanceAgent().getId();
+
 		super.getResponse().setAuthorised(status);
 	}
 

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogCreateService.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogCreateService.java
@@ -2,6 +2,7 @@
 package acme.features.assistanceAgent.trackingLog;
 
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -63,13 +64,10 @@ public class AssistanceAgentTrackingLogCreateService extends AbstractGuiService<
 
 	@Override
 	public void validate(final TrackingLog trackingLog) {
-		int claimId;
-		Claim claim;
+		List<TrackingLog> trackingLogs = this.repository.findTrackingLogsOrderByResolutionPercentage();
 
-		claimId = super.getRequest().getData("id", int.class);
-		claim = this.claimRepository.findClaimById(claimId);
-		if (claim.isDraftMode())
-			super.state(false, "draftMode", "acme.validation.confirmation.message.update");
+		if (!trackingLogs.isEmpty() && trackingLog.getResolutionPercentage() < trackingLogs.get(0).getResolutionPercentage())
+			super.state(false, "resolutionPercentage", "acme.validation.draftMode.message");
 	}
 
 	@Override

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogDeleteService.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogDeleteService.java
@@ -19,12 +19,15 @@ public class AssistanceAgentTrackingLogDeleteService extends AbstractGuiService<
 	@Autowired
 	private AssistanceAgentTrackingLogRepository repository;
 
+	// AbstractGuiService interface -------------------------------------------
+
 
 	@Override
 	public void authorise() {
 		boolean status;
 		int trackingLogId = super.getRequest().getData("id", int.class);
 		TrackingLog trackingLog = this.repository.findTrackingLogById(trackingLogId);
+
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && trackingLog != null;
 		super.getResponse().setAuthorised(status);
 	}

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogListService.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogListService.java
@@ -14,8 +14,12 @@ import acme.realms.AssistanceAgent;
 @GuiService
 public class AssistanceAgentTrackingLogListService extends AbstractGuiService<AssistanceAgent, TrackingLog> {
 
+	// Internal state ---------------------------------------------------------
+
 	@Autowired
 	private AssistanceAgentTrackingLogRepository repository;
+
+	// AbstractGuiService interface ------------------------------------------
 
 
 	@Override

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogPublishService.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogPublishService.java
@@ -23,7 +23,7 @@ public class AssistanceAgentTrackingLogPublishService extends AbstractGuiService
 	@Autowired
 	private AssistanceAgentTrackingLogRepository repository;
 
-	// AbstractGuiService interfaced ------------------------------------------
+	// AbstractGuiService interface ------------------------------------------
 
 
 	@Override
@@ -31,6 +31,7 @@ public class AssistanceAgentTrackingLogPublishService extends AbstractGuiService
 		boolean status;
 		int trackingLogId = super.getRequest().getData("id", int.class);
 		TrackingLog trackingLog = this.repository.findTrackingLogById(trackingLogId);
+
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && trackingLog != null;
 		super.getResponse().setAuthorised(status);
 	}

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogRepository.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogRepository.java
@@ -2,6 +2,7 @@
 package acme.features.assistanceAgent.trackingLog;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,4 +22,7 @@ public interface AssistanceAgentTrackingLogRepository extends AbstractRepository
 
 	@Query("SELECT tl.claim FROM TrackingLog tl WHERE tl.id = :id")
 	Claim findClaimByTrackingLogId(int id);
+
+	@Query("SELECT tl FROM TrackingLog tl ORDER BY tl.resolutionPercentage DESC")
+	List<TrackingLog> findTrackingLogsOrderByResolutionPercentage();
 }

--- a/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogUpdateService.java
+++ b/src/main/java/acme/features/assistanceAgent/trackingLog/AssistanceAgentTrackingLogUpdateService.java
@@ -2,6 +2,7 @@
 package acme.features.assistanceAgent.trackingLog;
 
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -23,7 +24,7 @@ public class AssistanceAgentTrackingLogUpdateService extends AbstractGuiService<
 	@Autowired
 	private AssistanceAgentTrackingLogRepository repository;
 
-	// AbstractGuiService interfaced ------------------------------------------
+	// AbstractGuiService interface ------------------------------------------
 
 
 	@Override
@@ -31,6 +32,7 @@ public class AssistanceAgentTrackingLogUpdateService extends AbstractGuiService<
 		boolean status;
 		int trackingLogId = super.getRequest().getData("id", int.class);
 		TrackingLog trackingLog = this.repository.findTrackingLogById(trackingLogId);
+
 		status = super.getRequest().getPrincipal().hasRealmOfType(AssistanceAgent.class) && trackingLog != null;
 		super.getResponse().setAuthorised(status);
 	}
@@ -57,6 +59,11 @@ public class AssistanceAgentTrackingLogUpdateService extends AbstractGuiService<
 
 	@Override
 	public void validate(final TrackingLog trackingLog) {
+		List<TrackingLog> trackingLogs = this.repository.findTrackingLogsOrderByResolutionPercentage();
+
+		if (!trackingLogs.isEmpty() && trackingLog.getResolutionPercentage() < trackingLogs.get(0).getResolutionPercentage())
+			super.state(false, "resolutionPercentage", "acme.validation.draftMode.message");
+
 		if (!trackingLog.isDraftMode())
 			super.state(false, "draftMode", "acme.validation.confirmation.message.update");
 	}


### PR DESCRIPTION
Corrijo la validación de los porcentajes de TrackingLog: al crear una trackingLog el porcentaje no puede ser menor al del último trackingLog